### PR TITLE
feat: generate package artifacts in build executor

### DIFF
--- a/docs/executors.md
+++ b/docs/executors.md
@@ -180,18 +180,22 @@ nx build my-app --sourcemap
 
 ### Options
 
-| Option           | Type       | Default              | Description                                                                                                       |
-| ---------------- | ---------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `outputPath`     | `string`   | from config          | Override the default output directory. By default, uses `dist/{projectRoot}` or the value from `astro.config.mjs` |
-| `mode`           | `string`   | -                    | Build mode: `'static'` for SSG or `'server'` for SSR (usually determined by astro.config.mjs)                     |
-| `root`           | `string`   | project root         | Project root path (provided by Nx automatically)                                                                  |
-| `config`         | `string`   | `"astro.config.mjs"` | Path to Astro config file                                                                                         |
-| `site`           | `string`   | -                    | Site URL for absolute URLs in production                                                                          |
-| `base`           | `string`   | -                    | Base path for deployment (e.g., `/blog` for subdirectory deployments)                                             |
-| `sourcemap`      | `boolean`  | `false`              | Generate source maps for debugging production builds                                                              |
-| `clean`          | `boolean`  | `true`               | Clean output directory before build                                                                               |
-| `verbose`        | `boolean`  | `false`              | Enable verbose output for debugging                                                                               |
-| `additionalArgs` | `string[]` | -                    | Additional CLI arguments to pass to Astro                                                                         |
+| Option                                | Type       | Default              | Description                                                                                                       |
+| ------------------------------------- | ---------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `outputPath`                          | `string`   | from config          | Override the default output directory. By default, uses `dist/{projectRoot}` or the value from `astro.config.mjs` |
+| `mode`                                | `string`   | -                    | Build mode: `'static'` for SSG or `'server'` for SSR (usually determined by astro.config.mjs)                     |
+| `root`                                | `string`   | project root         | Project root path (provided by Nx automatically)                                                                  |
+| `config`                              | `string`   | `"astro.config.mjs"` | Path to Astro config file                                                                                         |
+| `site`                                | `string`   | -                    | Site URL for absolute URLs in production                                                                          |
+| `base`                                | `string`   | -                    | Base path for deployment (e.g., `/blog` for subdirectory deployments)                                             |
+| `sourcemap`                           | `boolean`  | `false`              | Generate source maps for debugging production builds                                                              |
+| `clean`                               | `boolean`  | `true`               | Clean output directory before build                                                                               |
+| `verbose`                             | `boolean`  | `false`              | Enable verbose output for debugging                                                                               |
+| `additionalArgs`                      | `string[]` | -                    | Additional CLI arguments to pass to Astro                                                                         |
+| `generatePackageJson`                 | `boolean`  | `false`              | Generate `package.json` and lockfile artifacts in the build output directory                                      |
+| `includeDevDependenciesInPackageJson` | `boolean`  | `false`              | Include `devDependencies` in the generated `package.json`                                                         |
+| `skipOverrides`                       | `boolean`  | `false`              | Omit `overrides` from the generated `package.json`                                                                |
+| `skipPackageManager`                  | `boolean`  | `false`              | Omit `packageManager` from the generated `package.json`                                                           |
 
 ### Build Output
 

--- a/nx-astro/package.json
+++ b/nx-astro/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@nx/devkit": "22.7.1",
+    "@nx/js": "22.7.1",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {

--- a/nx-astro/src/executors/build/executor.spec.ts
+++ b/nx-astro/src/executors/build/executor.spec.ts
@@ -1,6 +1,16 @@
 import { ExecutorContext } from '@nx/devkit';
 import { BuildExecutorSchema } from './schema';
 
+const mockDetectPackageManager = jest.fn();
+
+jest.mock('@nx/devkit', () => {
+  const actual = jest.requireActual('@nx/devkit');
+  return {
+    ...actual,
+    detectPackageManager: mockDetectPackageManager,
+  };
+});
+
 // Mock child_process
 const mockExec = jest.fn();
 
@@ -24,6 +34,25 @@ const mockSyncAstrojsDependencies = jest.fn();
 
 jest.mock('../../utils/sync-astrojs-deps', () => ({
   syncAstrojsDependencies: mockSyncAstrojsDependencies,
+}));
+
+// Mock @nx/js package artifact helpers
+const mockCreatePackageJson = jest.fn();
+const mockCreateLockFile = jest.fn();
+const mockGetLockFileName = jest.fn();
+
+jest.mock('@nx/js', () => ({
+  createPackageJson: mockCreatePackageJson,
+  createLockFile: mockCreateLockFile,
+  getLockFileName: mockGetLockFileName,
+}));
+
+// Mock file system writes for generated artifacts
+const mockWriteFileSync = jest.fn();
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  writeFileSync: mockWriteFileSync,
 }));
 
 // Mock util with proper promisify implementation
@@ -84,6 +113,11 @@ describe('Build Executor', () => {
     mockExec.mockClear();
     mockBuildAstroCommandString.mockClear();
     mockSyncAstrojsDependencies.mockClear();
+    mockCreatePackageJson.mockClear();
+    mockCreateLockFile.mockClear();
+    mockGetLockFileName.mockClear();
+    mockDetectPackageManager.mockClear();
+    mockWriteFileSync.mockClear();
 
     // Default mock implementation - returns a command string
     mockBuildAstroCommandString.mockReturnValue(
@@ -95,6 +129,15 @@ describe('Build Executor', () => {
       callback(null, { stdout: 'Build successful', stderr: '' });
       return {} as any;
     });
+
+    mockCreatePackageJson.mockReturnValue({
+      name: 'my-app',
+      version: '0.0.0',
+      dependencies: {},
+    });
+    mockCreateLockFile.mockReturnValue('lockfile-content');
+    mockGetLockFileName.mockReturnValue('pnpm-lock.yaml');
+    mockDetectPackageManager.mockReturnValue('pnpm');
   });
 
   describe('basic build', () => {
@@ -410,6 +453,75 @@ describe('Build Executor', () => {
       // Verify buildAstroCommandString receives the workspace root for PM detection
       const calls = mockBuildAstroCommandString.mock.calls;
       expect(calls[0][2]).toBe('/workspace');
+    });
+  });
+
+  describe('package artifact generation', () => {
+    it('should not generate package artifacts by default', async () => {
+      const options: BuildExecutorSchema = {};
+
+      const result = await buildExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(mockCreatePackageJson).not.toHaveBeenCalled();
+      expect(mockCreateLockFile).not.toHaveBeenCalled();
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should generate package.json and lockfile when enabled', async () => {
+      const options: BuildExecutorSchema = {
+        generatePackageJson: true,
+        outputPath: 'dist/apps/my-app',
+      };
+
+      const result = await buildExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(mockCreatePackageJson).toHaveBeenCalled();
+      expect(mockCreateLockFile).toHaveBeenCalled();
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('should pass through package generation options to Nx helpers', async () => {
+      const options: BuildExecutorSchema = {
+        generatePackageJson: true,
+        includeDevDependenciesInPackageJson: true,
+        skipOverrides: true,
+        skipPackageManager: true,
+        outputPath: 'dist/apps/my-app',
+      };
+
+      await buildExecutor(options, context);
+
+      expect(mockCreatePackageJson).toHaveBeenCalledWith(
+        'my-app',
+        expect.any(Object),
+        expect.objectContaining({
+          isProduction: false,
+          skipOverrides: true,
+          skipPackageManager: true,
+        }),
+      );
+    });
+
+    it('should not generate package artifacts when build fails', async () => {
+      const options: BuildExecutorSchema = {
+        generatePackageJson: true,
+      };
+
+      mockExec.mockImplementation(
+        (cmd: string, options: any, callback: any) => {
+          callback(new Error('Build failed'), null);
+          return {} as any;
+        },
+      );
+
+      const result = await buildExecutor(options, context);
+
+      expect(result.success).toBe(false);
+      expect(mockCreatePackageJson).not.toHaveBeenCalled();
+      expect(mockCreateLockFile).not.toHaveBeenCalled();
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
   });
 });

--- a/nx-astro/src/executors/build/executor.spec.ts
+++ b/nx-astro/src/executors/build/executor.spec.ts
@@ -49,10 +49,12 @@ jest.mock('@nx/js', () => ({
 
 // Mock file system writes for generated artifacts
 const mockWriteFileSync = jest.fn();
+const mockMkdirSync = jest.fn();
 
 jest.mock('fs', () => ({
   ...jest.requireActual('fs'),
   writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
 }));
 
 // Mock util with proper promisify implementation
@@ -118,6 +120,7 @@ describe('Build Executor', () => {
     mockGetLockFileName.mockClear();
     mockDetectPackageManager.mockClear();
     mockWriteFileSync.mockClear();
+    mockMkdirSync.mockClear();
 
     // Default mock implementation - returns a command string
     mockBuildAstroCommandString.mockReturnValue(
@@ -479,7 +482,44 @@ describe('Build Executor', () => {
       expect(result.success).toBe(true);
       expect(mockCreatePackageJson).toHaveBeenCalled();
       expect(mockCreateLockFile).toHaveBeenCalled();
+      expect(mockMkdirSync).toHaveBeenCalledWith('dist/apps/my-app', {
+        recursive: true,
+      });
       expect(mockWriteFileSync).toHaveBeenCalledTimes(2);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('dist/apps/my-app/package.json'),
+        expect.any(String),
+        expect.any(Object),
+      );
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('dist/apps/my-app/pnpm-lock.yaml'),
+        'lockfile-content',
+        expect.any(Object),
+      );
+    });
+
+    it('should not write lockfile for bun workspaces', async () => {
+      const options: BuildExecutorSchema = {
+        generatePackageJson: true,
+        outputPath: 'dist/apps/my-app',
+      };
+
+      mockDetectPackageManager.mockReturnValue('bun');
+      mockGetLockFileName.mockReturnValue('bun.lock');
+      mockCreateLockFile.mockReturnValue('');
+
+      const result = await buildExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(mockMkdirSync).toHaveBeenCalledWith('dist/apps/my-app', {
+        recursive: true,
+      });
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('dist/apps/my-app/package.json'),
+        expect.any(String),
+        expect.any(Object),
+      );
     });
 
     it('should pass through package generation options to Nx helpers', async () => {
@@ -497,6 +537,8 @@ describe('Build Executor', () => {
         'my-app',
         expect.any(Object),
         expect.objectContaining({
+          target: 'build',
+          root: '/workspace',
           isProduction: false,
           skipOverrides: true,
           skipPackageManager: true,

--- a/nx-astro/src/executors/build/executor.ts
+++ b/nx-astro/src/executors/build/executor.ts
@@ -1,6 +1,8 @@
-import { ExecutorContext, logger } from '@nx/devkit';
+import { ExecutorContext, detectPackageManager, logger } from '@nx/devkit';
+import { createLockFile, createPackageJson, getLockFileName } from '@nx/js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { writeFileSync } from 'fs';
 import * as path from 'path';
 import { BuildExecutorSchema } from './schema';
 import { buildAstroCommandString } from '../../utils/command-builder';
@@ -96,6 +98,36 @@ export default async function buildExecutor(
     }
 
     logger.info('Build completed successfully');
+
+    if (options.generatePackageJson) {
+      const outputPath =
+        options.outputPath || path.join('dist', projectConfig.root);
+      const packageJson = createPackageJson(projectName, context.projectGraph, {
+        target: context.targetName,
+        root: context.root,
+        isProduction: !options.includeDevDependenciesInPackageJson,
+        skipOverrides: options.skipOverrides,
+        skipPackageManager: options.skipPackageManager,
+      });
+      const packageManager = detectPackageManager(context.root);
+      const lockFileName = getLockFileName(packageManager);
+      const lockFile = createLockFile(
+        packageJson,
+        context.projectGraph,
+        packageManager,
+      );
+
+      writeFileSync(
+        path.join(outputPath, 'package.json'),
+        `${JSON.stringify(packageJson, null, 2)}\n`,
+        {
+          encoding: 'utf-8',
+        },
+      );
+      writeFileSync(path.join(outputPath, lockFileName), lockFile, {
+        encoding: 'utf-8',
+      });
+    }
 
     return { success: true };
   } catch (error) {

--- a/nx-astro/src/executors/build/executor.ts
+++ b/nx-astro/src/executors/build/executor.ts
@@ -2,7 +2,7 @@ import { ExecutorContext, detectPackageManager, logger } from '@nx/devkit';
 import { createLockFile, createPackageJson, getLockFileName } from '@nx/js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { writeFileSync } from 'fs';
+import { mkdirSync, writeFileSync } from 'fs';
 import * as path from 'path';
 import { BuildExecutorSchema } from './schema';
 import { buildAstroCommandString } from '../../utils/command-builder';
@@ -117,6 +117,8 @@ export default async function buildExecutor(
         packageManager,
       );
 
+      mkdirSync(outputPath, { recursive: true });
+
       writeFileSync(
         path.join(outputPath, 'package.json'),
         `${JSON.stringify(packageJson, null, 2)}\n`,
@@ -124,9 +126,11 @@ export default async function buildExecutor(
           encoding: 'utf-8',
         },
       );
-      writeFileSync(path.join(outputPath, lockFileName), lockFile, {
-        encoding: 'utf-8',
-      });
+      if (packageManager !== 'bun' && lockFile) {
+        writeFileSync(path.join(outputPath, lockFileName), lockFile, {
+          encoding: 'utf-8',
+        });
+      }
     }
 
     return { success: true };

--- a/nx-astro/src/executors/build/schema.d.ts
+++ b/nx-astro/src/executors/build/schema.d.ts
@@ -52,4 +52,28 @@ export interface BuildExecutorSchema {
    * Additional CLI arguments to pass to Astro
    */
   additionalArgs?: string[];
+
+  /**
+   * Generate package.json and lockfile in the output path
+   * @default false
+   */
+  generatePackageJson?: boolean;
+
+  /**
+   * Include devDependencies in generated package.json
+   * @default false
+   */
+  includeDevDependenciesInPackageJson?: boolean;
+
+  /**
+   * Skip overrides field in generated package.json
+   * @default false
+   */
+  skipOverrides?: boolean;
+
+  /**
+   * Skip packageManager field in generated package.json
+   * @default false
+   */
+  skipPackageManager?: boolean;
 }

--- a/nx-astro/src/executors/build/schema.json
+++ b/nx-astro/src/executors/build/schema.json
@@ -52,6 +52,26 @@
       "items": {
         "type": "string"
       }
+    },
+    "generatePackageJson": {
+      "type": "boolean",
+      "description": "Generate package.json and lockfile in the output path",
+      "default": false
+    },
+    "includeDevDependenciesInPackageJson": {
+      "type": "boolean",
+      "description": "Include devDependencies in generated package.json",
+      "default": false
+    },
+    "skipOverrides": {
+      "type": "boolean",
+      "description": "Skip overrides field in generated package.json",
+      "default": false
+    },
+    "skipPackageManager": {
+      "type": "boolean",
+      "description": "Skip packageManager field in generated package.json",
+      "default": false
     }
   },
   "required": []


### PR DESCRIPTION
## Summary
- add opt-in build executor support for generating `package.json` and lockfile artifacts using `@nx/js` helpers
- add build executor options for `generatePackageJson`, `includeDevDependenciesInPackageJson`, `skipOverrides`, and `skipPackageManager`
- add unit tests and executor docs covering default-off behavior and option pass-through

## Test plan
- pnpm exec nx lint nx-astro
- pnpm exec nx test nx-astro
- pnpm exec nx build nx-astro

Closes #38