### PR TITLE
Potential fix for code scanning alert no. 12: Insecure temporary file

### DIFF
--- a/tools/scripts/start-local-registry.ts
+++ b/tools/scripts/start-local-registry.ts
@@ -12,16 +12,15 @@
 
 import { execSync } from 'child_process';
 import { join } from 'path';
-import { cpSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { cpSync, mkdtempSync, readFileSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 
 export default async () => {
   console.log('Starting E2E test preparation...');
 
   try {
-    // Create temp directory for E2E package (unique per run)
-    const tempDir = join(tmpdir(), 'nx-astro-e2e-' + Date.now());
-    mkdirSync(tempDir, { recursive: true });
+    // Create temp directory for E2E package (securely, unique per run)
+    const tempDir = mkdtempSync(join(tmpdir(), 'nx-astro-e2e-'));
     console.log(`Created temp directory: ${tempDir}`);
 
     // Copy built package to temp directory


### PR DESCRIPTION
Potential fix for [https://github.com/Geekvetica/nx-astro/security/code-scanning/12](https://github.com/Geekvetica/nx-astro/security/code-scanning/12)

Use a securely created unique temp directory instead of constructing one with `Date.now()`. In Node.js, the best built-in fix is `mkdtempSync`, which atomically creates a new directory with a random suffix, preventing name prediction and race/pre-creation issues.

In `tools/scripts/start-local-registry.ts`:
- Update the `fs` import to include `mkdtempSync`.
- Replace the `tempDir` creation block (current `join(tmpdir(), ...Date.now())` + `mkdirSync`) with a single `mkdtempSync(join(tmpdir(), 'nx-astro-e2e-'))`.
- Keep the rest of the logic unchanged (copy, modify package.json, pack, etc.).

No functionality change is required; it still creates an isolated temp directory and stores it in `process.env.E2E_TEMP_DIR`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
